### PR TITLE
Few fixes for latest python3

### DIFF
--- a/orgparse/date.py
+++ b/orgparse/date.py
@@ -476,8 +476,8 @@ class OrgDateClock(OrgDate):
         >>> duration = OrgDateClock.from_str(
         ...   'CLOCK: [2010-08-08 Sun 17:00]--[2010-08-08 Sun 17:30] => 0:30'
         ... ).duration
-        >>> duration
-        datetime.timedelta(0, 1800)
+        >>> duration.seconds
+        1800
         >>> total_minutes(duration)
         30.0
 

--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -796,7 +796,10 @@ class OrgNode(OrgBaseNode):
         They are assumed be in the first line.
 
         """
-        line = next(ilines)
+        try:
+            line = next(ilines)
+        except StopIteration:
+            return
         (self._scheduled, self._deadline, self._closed) = parse_sdc(line)
 
         if not (self._scheduled or

--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -1,9 +1,9 @@
 import re
 import itertools
 try:
-    from collections import Sequence
-except ImportError:
     from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from .date import OrgDate, OrgDateClock, OrgDateRepeatedTask, parse_sdc
 from .inline import to_plain_text

--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -548,7 +548,10 @@ class OrgBaseNode(Sequence):
     # FIXME: cache children nodes
     def _find_children(self):
         nodeiter = iter(self.env._nodes[self._index + 1:])
-        node = next(nodeiter)
+        try:
+            node = next(nodeiter)
+        except StopIteration:
+            return
         if node.level <= self.level:
             return
         yield node

--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -769,7 +769,10 @@ class OrgNode(OrgBaseNode):
         self._parse_heading()
         # FIXME: make the following parsers "lazy"
         ilines = iter(self._lines)
-        next(ilines)            # skip heading
+        try:
+            next(ilines)            # skip heading
+        except StopIteration:
+            return
         ilines = self._iparse_sdc(ilines)
         ilines = self._iparse_clock(ilines)
         ilines = self._iparse_properties(ilines)

--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -37,7 +37,7 @@ def parse_heading_level(heading):
     if match:
         return (match.group(2), len(match.group(1)))
 
-RE_HEADING_STARS = re.compile('^(\*+)\s*(.*?)\s*$')
+RE_HEADING_STARS = re.compile(r'^(\*+)\s*(.*?)\s*$')
 
 
 def parse_heading_tags(heading):
@@ -137,7 +137,7 @@ def parse_property(line):
                 prop_val = int(h) * 60 + int(m)
     return (prop_key, prop_val)
 
-RE_PROP = re.compile('^\s*:(.*?):\s*(.*?)\s*$')
+RE_PROP = re.compile(r'^\s*:(.*?):\s*(.*?)\s*$')
 
 
 def parse_comment(line):

--- a/orgparse/tests/data/02_tree_struct.py
+++ b/orgparse/tests/data/02_tree_struct.py
@@ -36,4 +36,6 @@ data = [nodedict(*args) for args in [
     ('G6-H2',),
     ('G6-H2',),
     ('G6-H1', [], 'G6-H2'),
+    # G7
+    (None, [], 'G6-H1'),
 ]]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32
+envlist = py26, py27, py36
 [testenv]
 deps =
   nose


### PR DESCRIPTION
Hey, I've fixed few issues which reproduce on python3.7, mainly to the way [`StopIteration` handling changed](https://www.python.org/dev/peps/pep-0479/), also some warnings.

Sadly python3.7 is not available in Travis without messing with default image, so I left setting it up for later.

Wondering if you merge it, will you be able to draft a new release?

P.S. also thanks for the library, I've looked at quite a few python parsers on github and this one seems the most robust, well tested and comprehensive despite not being updated for 7 years :) 