### PR TITLE
Ignore commented clock expressions and SCHEDULED/DEADLINE/CLOSED markers

### DIFF
--- a/orgparse/date.py
+++ b/orgparse/date.py
@@ -421,7 +421,7 @@ class OrgDate(object):
 def compile_sdc_re(sdctype):
     brtype = 'inactive' if sdctype == 'CLOSED' else 'active'
     return re.compile(
-        r'{0}:\s+{1}'.format(
+        r'^(?!\#).*{0}:\s+{1}'.format(
             sdctype,
             gene_timestamp_regex(brtype, prefix='', nocookie=True)),
         re.VERBOSE)

--- a/orgparse/date.py
+++ b/orgparse/date.py
@@ -551,7 +551,7 @@ class OrgDateClock(OrgDate):
         )
 
     _re = re.compile(
-        r'CLOCK:\s+'
+        r'^(?!#).*CLOCK:\s+'
         r'\[(\d+)\-(\d+)\-(\d+)[^\]\d]*(\d+)\:(\d+)\]--'
         r'\[(\d+)\-(\d+)\-(\d+)[^\]\d]*(\d+)\:(\d+)\]\s+=>\s+(\d+)\:(\d+)'
         )

--- a/orgparse/tests/test_data.py
+++ b/orgparse/tests/test_data.py
@@ -90,3 +90,42 @@ def test_iter_node():
 
     by_iter = [n.heading for n in node]
     assert by_iter == ['H1', 'H2', 'H3']
+
+
+def test_commented_headings_do_not_appear_as_children():
+    root = loads("""
+* H1
+#** H2
+** H3
+#* H4
+#** H5
+* H6
+""")
+    top_level = root.children
+    assert len(top_level) == 2
+
+    h1 = top_level[0]
+    assert h1.heading == "H1"
+    assert h1.get_body() == "#** H2"
+
+    [h3] = h1.children
+    assert h3.heading == "H3"
+    assert h3.get_body() == "#* H4\n#** H5"
+
+    h6 = top_level[1]
+    assert h6.heading == "H6"
+    assert len(h6.children) == 0
+
+
+def test_commented_clock_entries_are_ignored_by_node_clock():
+    root = loads("""
+* Heading
+# * Floss
+# SCHEDULED: <2019-06-22 Sat 08:30 .+1w>
+# :LOGBOOK:
+# CLOCK: [2019-06-04 Tue 16:00]--[2019-06-04 Tue 17:00] =>  1:00
+# :END:
+""")
+    [node] = root.children[0]
+    assert node.heading == "Heading"
+    assert node.clock == []

--- a/orgparse/tests/test_data.py
+++ b/orgparse/tests/test_data.py
@@ -93,7 +93,7 @@ def test_iter_node():
 
 
 def test_commented_headings_do_not_appear_as_children():
-    root = loads("""
+    root = loads("""\
 * H1
 #** H2
 ** H3
@@ -118,7 +118,7 @@ def test_commented_headings_do_not_appear_as_children():
 
 
 def test_commented_clock_entries_are_ignored_by_node_clock():
-    root = loads("""
+    root = loads("""\
 * Heading
 # * Floss
 # SCHEDULED: <2019-06-22 Sat 08:30 .+1w>
@@ -132,7 +132,7 @@ def test_commented_clock_entries_are_ignored_by_node_clock():
 
 
 def test_commented_scheduled_marker_is_ignored_by_node_scheduled():
-    root = loads("""
+    root = loads("""\
 * Heading
 # SCHEDULED: <2019-06-22 Sat 08:30 .+1w>
 """)

--- a/orgparse/tests/test_data.py
+++ b/orgparse/tests/test_data.py
@@ -139,3 +139,15 @@ def test_commented_scheduled_marker_is_ignored_by_node_scheduled():
     [node] = root.children[0]
     assert node.heading == "Heading"
     assert node.scheduled.start is None
+
+
+def test_commented_property_is_ignored_by_node_get_property():
+    root = loads("""\
+* Heading
+# :PROPERTIES:
+# :PROPER-TEA: backup
+# :END:
+""")
+    [node] = root.children[0]
+    assert node.heading == "Heading"
+    assert node.get_property("PROPER-TEA") is None

--- a/orgparse/tests/test_data.py
+++ b/orgparse/tests/test_data.py
@@ -129,3 +129,13 @@ def test_commented_clock_entries_are_ignored_by_node_clock():
     [node] = root.children[0]
     assert node.heading == "Heading"
     assert node.clock == []
+
+
+def test_commented_scheduled_marker_is_ignored_by_node_scheduled():
+    root = loads("""
+* Heading
+# SCHEDULED: <2019-06-22 Sat 08:30 .+1w>
+""")
+    [node] = root.children[0]
+    assert node.heading == "Heading"
+    assert node.scheduled.start is None


### PR DESCRIPTION
Hi, this fixes a bug where clocks that are commented out nevertheless show up in `node.clocks`.  Also for `SCHEDULED` markers etc, which would also still be treated as present when commented out.

Note caveats in the commit messages.