### PR TITLE
Allow to pass a custom OrgEnv instance when loading content

### DIFF
--- a/orgparse/__init__.py
+++ b/orgparse/__init__.py
@@ -122,7 +122,7 @@ __license__ = 'BSD License'
 __all__ = ["load", "loads", "loadi"]
 
 
-def load(path):
+def load(path, env=None):
     """
     Load org-mode document from a file.
 
@@ -139,24 +139,24 @@ def load(path):
         orgfile = path
         filename = path.name if hasattr(path, 'name') else '<file-like>'
     return loadi((l.rstrip('\n') for l in orgfile.readlines()),
-                 filename=filename)
+                 filename=filename, env=env)
 
 
-def loads(string, filename='<string>'):
+def loads(string, filename='<string>', env=None):
     """
     Load org-mode document from a string.
 
     :rtype: :class:`orgparse.node.OrgRootNode`
 
     """
-    return loadi(string.splitlines(), filename=filename)
+    return loadi(string.splitlines(), filename=filename, env=env)
 
 
-def loadi(lines, filename='<lines>'):
+def loadi(lines, filename='<lines>', env=None):
     """
     Load org-mode document from an iterative object.
 
     :rtype: :class:`orgparse.node.OrgRootNode`
 
     """
-    return parse_lines(lines, filename=filename)
+    return parse_lines(lines, filename=filename, env=env)

--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -1259,7 +1259,7 @@ class OrgNode(OrgBaseNode):
 def parse_lines(lines, filename, env=None):
     if not env:
         env = OrgEnv(filename=filename)
-    elif env and env.filename != filename:
+    elif env.filename != filename:
         raise ValueError('If env is specified, filename must match')
 
     # parse into node of list (environment will be parsed)

--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -1256,8 +1256,12 @@ class OrgNode(OrgBaseNode):
         return self._repeated_tasks
 
 
-def parse_lines(lines, filename):
-    env = OrgEnv(filename=filename)
+def parse_lines(lines, filename, env=None):
+    if not env:
+        env = OrgEnv(filename=filename)
+    elif env and env.filename != filename:
+        raise ValueError('If env is specified, filename must match')
+
     # parse into node of list (environment will be parsed)
     nodelist = list(env.from_chunks(lines_to_chunks(lines)))
     # parse headings (level, TODO, TAGs, and heading)

--- a/orgparse/tests/test_misc.py
+++ b/orgparse/tests/test_misc.py
@@ -1,11 +1,13 @@
 from .. import load, loads
+from ..node import OrgEnv
+
 
 def test_stars():
     # https://github.com/karlicoss/orgparse/issues/7#issuecomment-533732660
     root = loads("""
 * Heading with text (A)
 
-The following line is not a heading, because it begins with a 
+The following line is not a heading, because it begins with a
 star but has no spaces afterward, just a newline:
 
 *
@@ -33,3 +35,50 @@ This subheading is a child of the "anonymous" heading (B), not of heading (A).
     assert h1.heading == 'Heading with text (A)'
     assert h2.heading == ''
 
+
+def test_parse_custom_todo_keys():
+    todo_keys = ['TODO', 'CUSTOM1', 'ANOTHER_KEYWORD']
+    done_keys = ['DONE', 'A']
+    filename = '<string>'  # default for loads
+    content = """
+* TODO Heading with a default todo keyword
+
+* DONE Heading with a default done keyword
+
+* CUSTOM1 Heading with a custom todo keyword
+
+* ANOTHER_KEYWORD Heading with a long custom todo keyword
+
+* A Heading with a short custom done keyword
+    """
+
+    env = OrgEnv(todos=todo_keys, dones=done_keys, filename=filename)
+    root = loads(content, env=env)
+
+    assert root.env.all_todo_keys == ['TODO', 'CUSTOM1',
+                                      'ANOTHER_KEYWORD', 'DONE', 'A']
+    assert len(root.children) == 5
+    assert root.children[0].todo == 'TODO'
+    assert root.children[1].todo == 'DONE'
+    assert root.children[2].todo == 'CUSTOM1'
+    assert root.children[3].todo == 'ANOTHER_KEYWORD'
+    assert root.children[4].todo == 'A'
+
+
+def test_add_custom_todo_keys():
+    todo_keys = ['CUSTOM_TODO']
+    done_keys = ['CUSTOM_DONE']
+    filename = '<string>'  # default for loads
+    content = """#+TODO: COMMENT_TODO | COMMENT_DONE 
+    """
+
+    env = OrgEnv(filename=filename)
+    env.add_todo_keys(todos=todo_keys, dones=done_keys)
+
+    # check that only the custom keys are know before parsing
+    assert env.all_todo_keys == ['CUSTOM_TODO', 'CUSTOM_DONE']
+
+    # after parsing, all keys are set
+    root = loads(content, filename, env)
+    assert root.env.all_todo_keys == ['CUSTOM_TODO', 'COMMENT_TODO',
+                                      'CUSTOM_DONE', 'COMMENT_DONE']


### PR DESCRIPTION
In the current implementation the OrgEnv instance is created inside the
`parse_lines()` method with the only customizable argument being the
filename. In this change the methods `load()`/`loads()`/`loadi()` are extended by an optional `env` argument to pass it in when loading content.

Fixes #18 