### PR TITLE
feat: add title in orgparse object in title method

### DIFF
--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -152,8 +152,8 @@ def parse_comment(line):
     >>> parse_comment('# not a special comment')  # None
 
     """
-    if line.startswith('#+'):
-        comment = line.lstrip('#+').split(':', 1)
+    if re.match(r'\s*#\+', line):
+        comment = re.split(r':\s+', re.split(r'\s*#\+',line)[1])
         if len(comment) == 2:
             return (comment[0], comment[1].strip())
 
@@ -716,6 +716,27 @@ class OrgBaseNode(Sequence):
     else:
         def __str__(self):
             return unicode(self).encode('utf-8')
+
+    def get_file_property(self, property):
+        """
+        Return a list of the selected property
+        """
+        print(self._special_comments)
+        if property in self._special_comments:
+            return self._special_comments[property]
+        else:
+            return None
+
+    def get_only_file_property(self, property):
+        """
+        Return a single element of the selected property
+        """
+        elements = self.get_file_property(property)
+        if elements:
+            return elements[0]
+        else:
+            return None
+
 
 
 class OrgRootNode(OrgBaseNode):

--- a/orgparse/tests/test_misc.py
+++ b/orgparse/tests/test_misc.py
@@ -82,3 +82,38 @@ def test_add_custom_todo_keys():
     root = loads(content, filename, env)
     assert root.env.all_todo_keys == ['CUSTOM_TODO', 'COMMENT_TODO',
                                       'CUSTOM_DONE', 'COMMENT_DONE']
+
+def test_get_custom_property():
+     filename = '<string>'  # default for loads
+     content = """#+TITLE: Test title
+     * Node 1
+     test 1
+     * Node 2
+     test 2
+     """
+
+     env = OrgEnv(filename=filename)
+
+     # after parsing, all keys are set
+     root = loads(content, filename, env)
+     assert root.get_file_property('TITLE') == ['Test title']
+     assert root.get_only_file_property('TITLE') == 'Test title'
+
+def test_get_custom_property_multivalued():
+     filename = '<string>'  # default for loads
+     content = """#+TITLE: Test
+     #+OTHER: Test title
+     #+TITLE: alternate title
+
+     * Node 1
+     test 1
+     * Node 2
+     test 2
+     """
+
+     env = OrgEnv(filename=filename)
+
+     # after parsing, all keys are set
+     root = loads(content, filename, env)
+     assert root.get_file_property('TITLE') == ['Test', 'alternate title']
+     assert root.get_only_file_property('TITLE') == 'Test'


### PR DESCRIPTION
add title method in org parse object in order to get title options

this point is often standard in org mode file.

thanks for accept the PR.

Best regards