### PR TITLE
Change + to * for repeated tasks to allow for entries at root

### DIFF
--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -1076,7 +1076,7 @@ class OrgNode(OrgBaseNode):
 
     _repeated_tasks_re = re.compile(
         r'''
-        \s+ - \s+
+        \s*- \s+
         State \s+ "(?P<done> [^"]+)" \s+
         from  \s+ "(?P<todo> [^"]+)" \s+
         \[ (?P<date> [^\]]+) \]''',


### PR DESCRIPTION
I'm using orgparse to parse my habits file, which may some times get written to by this app called Orgzly. Orgzly, for whatever reason, puts logbook entries without any spaces at the start.  See top logbook entry below.

```
  :LOGBOOK:
- State "DONE"       from "TODO"       [2021-06-29 Tue 18:33]
  - State "DONE"       from "TODO"       [2021-06-27 Sun 20:29]
  - State "DONE"       from "TODO"       [2021-06-28 Mon 20:29]
  :END:
```

As far as I can tell that's valid org (and emacs treats it as such which I guess is the ultimate test). The change in regex I'm proposing here allows orgparse to read that data correctly. I have no idea if this has any unintended consequences tho.

Thanks for the library, it's been great!