### PR TITLE
Harmonize SDC date objects

### DIFF
--- a/orgparse/node.py
+++ b/orgparse/node.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from collections import Sequence
 
-from .date import OrgDate, OrgDateClock, OrgDateRepeatedTask, parse_sdc
+from .date import OrgDate, OrgDateClock, OrgDateRepeatedTask, parse_sdc, OrgDateScheduled, OrgDateDeadline, OrgDateClosed
 from .inline import to_plain_text
 from .extra import to_rich_text, Rich
 from .utils.py3compat import PY3, unicode
@@ -963,9 +963,9 @@ class OrgNode(OrgBaseNode):
         self._todo: Optional[str] = None
         self._priority = None
         self._properties: Dict[str, PropertyValue] = {}
-        self._scheduled = OrgDate(None)
-        self._deadline = OrgDate(None)
-        self._closed = OrgDate(None)
+        self._scheduled = OrgDateScheduled(None)
+        self._deadline = OrgDateDeadline(None)
+        self._closed = OrgDateClosed(None)
         self._timestamps: List[OrgDate] = []
         self._clocklist: List[OrgDateClock] = []
         self._body_lines: List[str] = []

--- a/orgparse/tests/data/01_attributes.org
+++ b/orgparse/tests/data/01_attributes.org
@@ -25,3 +25,5 @@
 * range in deadline
 DEADLINE: <2019-09-06 Fri 10:00--11:20>
   body
+* node with a second line but no date
+body

--- a/orgparse/tests/data/01_attributes.py
+++ b/orgparse/tests/data/01_attributes.py
@@ -34,9 +34,9 @@ node1: Raw = dict(
 node2: Raw = dict(
     heading="A node without any attributed",
     priority=None,
-    scheduled=OrgDate(None),
-    deadline=OrgDate(None),
-    closed=OrgDate(None),
+    scheduled=OrgDateScheduled(None),
+    deadline=OrgDateDeadline(None),
+    closed=OrgDateClosed(None),
     clock=[],
     properties={},
     datelist=[],
@@ -47,9 +47,9 @@ node2: Raw = dict(
 node3: Raw = dict(
     heading="range in deadline",
     priority=None,
-    scheduled=OrgDate(None),
+    scheduled=OrgDateScheduled(None),
     deadline=OrgDateDeadline((2019, 9, 6, 10, 0), (2019, 9, 6, 11, 20)),
-    closed=OrgDate(None),
+    closed=OrgDateClosed(None),
     clock=[],
     properties={},
     datelist=[],
@@ -57,4 +57,17 @@ node3: Raw = dict(
     body="  body",
 )
 
-data = [node1, node2, node1, node3]
+node4: Raw = dict(
+    heading="node with a second line but no date",
+    priority=None,
+    scheduled=OrgDateScheduled(None),
+    deadline=OrgDateDeadline(None),
+    closed=OrgDateClosed(None),
+    clock=[],
+    properties={},
+    datelist=[],
+    rangelist=[],
+    body="body",
+)
+
+data = [node1, node2, node1, node3, node4]

--- a/orgparse/tests/test_data.py
+++ b/orgparse/tests/test_data.py
@@ -65,6 +65,7 @@ def test_data(dataname):
         for key in kwds:
             val = value_from_data_key(node, key)
             assert kwds[key] == val, 'check value of {0}-th node of key "{1}" from "{2}".\n\nParsed:\n{3}\n\nReal:\n{4}'.format(i, key, dataname, val, kwds[key])
+            assert type(kwds[key]) == type(val), 'check type of {0}-th node of key "{1}" from "{2}".\n\nParsed:\n{3}\n\nReal:\n{4}'.format(i, key, dataname, type(val), type(kwds[key]))
 
     assert root.env.filename == oname
 


### PR DESCRIPTION
Nodes with only the heading returned OrgDate(None) for all SDC dates whereas nodes with multiple lines had the more precise object OrgDateScheduled(None)/... This PR harmonizes these cases by returning the more precise object in each case.

I also hardened the parsing tests by adding a type check (strict type equality between parsed and expected). The type check could be relaxed by checking that the parsed object is a subclass of the expected type.

With the PR, the example in #40 gives:
```
from orgparse import loads
r0 = loads("""* Heading 1
* Heading 2
  body""")

print([c.scheduled for c in r0.children])  # prints [OrgDateScheduled(None), OrgDateScheduled(None)]
```

Solves issue #40