### PR TITLE
Fixed OrgDate._as_datetime, added test

### DIFF
--- a/orgparse/date.py
+++ b/orgparse/date.py
@@ -333,8 +333,12 @@ class OrgDate(object):
         return False
 
     @staticmethod
-    def _as_datetime(date):
-        if isinstance(date, datetime.date):
+    def _as_datetime(date) -> datetime.datetime:
+        """
+        Convert the given date into datetime (if it already is, return it
+        unmodified
+        """
+        if not isinstance(date, datetime.datetime):
             return datetime.datetime(*date.timetuple()[:3])
         return date
 

--- a/orgparse/tests/test_date.py
+++ b/orgparse/tests/test_date.py
@@ -1,0 +1,10 @@
+from orgparse.date import OrgDate
+import datetime
+
+
+def test_date_as_datetime() -> None:
+    testdate = (2021, 9, 3)
+    testdatetime = (2021, 9, 3, 16, 19, 13)
+
+    assert OrgDate._as_datetime(datetime.date(*testdate)) == datetime.datetime(*testdate, 0, 0, 0)
+    assert OrgDate._as_datetime(datetime.datetime(*testdatetime)) == datetime.datetime(*testdatetime)


### PR DESCRIPTION
when a datetime object was passed, time information got lost
(`datetime.datetime` is a child of `datetime.date`, so datetime objects
were wrongly converted)