### PR TITLE
Added __str__() to OrgDate

### DIFF
--- a/orgparse/date.py
+++ b/orgparse/date.py
@@ -133,6 +133,28 @@ def gene_timestamp_regex(brtype, prefix=None, nocookie=False):
     return regex.format(prefix=prefix, ignore=ignore)
 
 
+def date_time_format(date) -> str:
+    """
+    Format a date or datetime in default org format
+
+    @param date The date
+
+    @return Formatted date(time)
+    """
+    default_format_date = "%Y-%m-%d %a"
+    default_format_datetime = "%Y-%m-%d %a %H:%M"
+    is_datetime = isinstance(date, datetime.datetime)
+
+    return date.strftime(default_format_datetime if is_datetime else default_format_date)
+
+
+def is_same_day(date0, date1) -> bool:
+    """
+    Check if two dates or datetimes are on the same day
+    """
+    return (OrgDate._date_to_tuple(date0)[:3] == OrgDate._date_to_tuple(date1)[:3])
+
+
 TIMESTAMP_NOBRACE_RE = re.compile(
     gene_timestamp_regex('nobrace', prefix=''),
     re.VERBOSE)
@@ -153,6 +175,14 @@ class OrgDate(object):
     This value will be used.
 
     """
+
+    """
+    When formatting the date to string via __str__, and there is an end date on
+    the same day as the start date, allow formatting in the short syntax
+    <2021-09-03 Fri 16:01--17:30>? Otherwise the string represenation would be
+    <2021-09-03 Fri 16:01>--<2021-09-03 Fri 17:30>
+    """
+    _allow_short_range = True
 
     def __init__(self, start, end=None, active=None):
         """
@@ -231,6 +261,24 @@ class OrgDate(object):
             return '{0}({1!r}, {2!r})'.format(*args)
         else:
             return '{0}({1!r}, {2!r}, {3!r})'.format(*args)
+
+    def __str__(self):
+        fence = ("<", ">") if self.is_active() else ("[", "]")
+
+        start = date_time_format(self.start)
+        end = None
+
+        if self.has_end():
+            if self._allow_short_range and is_same_day(self.start, self.end):
+                start += "--%s" % self.end.strftime("%H:%M")
+            else:
+                end = date_time_format(self.end)
+
+        ret = "%s%s%s" % (fence[0], start, fence[1])
+        if end:
+            ret += "--%s%s%s" % (fence[0], end, fence[1])
+
+        return ret
 
     def __nonzero__(self):
         return bool(self._start)
@@ -493,6 +541,8 @@ class OrgDateClock(OrgDate):
     """
 
     _active_default = False
+
+    _allow_short_range = False
 
     def __init__(self, start, end, duration=None, active=None):
         """

--- a/orgparse/tests/test_date.py
+++ b/orgparse/tests/test_date.py
@@ -1,0 +1,31 @@
+from orgparse.date import OrgDate, OrgDateScheduled, OrgDateDeadline, OrgDateClock, OrgDateClosed
+import datetime
+
+
+def test_date_as_string() -> None:
+
+    testdate = datetime.date(2021, 9, 3)
+    testdate2 = datetime.date(2021, 9, 5)
+    testdatetime = datetime.datetime(2021, 9, 3, 16, 19, 13)
+    testdatetime2 = datetime.datetime(2021, 9, 3, 17, 0, 1)
+    testdatetime_nextday = datetime.datetime(2021, 9, 4, 0, 2, 1)
+
+    assert str(OrgDate(testdate)) == "<2021-09-03 Fri>"
+    assert str(OrgDate(testdatetime)) == "<2021-09-03 Fri 16:19>"
+    assert str(OrgDate(testdate, active=False)) == "[2021-09-03 Fri]"
+    assert str(OrgDate(testdatetime, active=False)) == "[2021-09-03 Fri 16:19]"
+
+    assert str(OrgDate(testdate, testdate2)) == "<2021-09-03 Fri>--<2021-09-05 Sun>"
+    assert str(OrgDate(testdate, testdate2)) == "<2021-09-03 Fri>--<2021-09-05 Sun>"
+    assert str(OrgDate(testdate, testdate2, active=False)) == "[2021-09-03 Fri]--[2021-09-05 Sun]"
+    assert str(OrgDate(testdate, testdate2, active=False)) == "[2021-09-03 Fri]--[2021-09-05 Sun]"
+
+    assert str(OrgDateScheduled(testdate)) == "<2021-09-03 Fri>"
+    assert str(OrgDateScheduled(testdatetime)) == "<2021-09-03 Fri 16:19>"
+    assert str(OrgDateDeadline(testdate)) == "<2021-09-03 Fri>"
+    assert str(OrgDateDeadline(testdatetime)) == "<2021-09-03 Fri 16:19>"
+    assert str(OrgDateClosed(testdate)) == "[2021-09-03 Fri]"
+    assert str(OrgDateClosed(testdatetime)) == "[2021-09-03 Fri 16:19]"
+
+    assert str(OrgDateClock(testdatetime, testdatetime2)) == "[2021-09-03 Fri 16:19]--[2021-09-03 Fri 17:00]"
+    assert str(OrgDateClock(testdatetime, testdatetime_nextday)) == "[2021-09-03 Fri 16:19]--[2021-09-04 Sat 00:02]"


### PR DESCRIPTION
Added support to convert OrgDate and its descendants into strings, using the default org formats

- use "<>" or "[]" depending on the `active` flag
- support for ranges (use short format `<2021-09-03 Fri 16:01--17:02>` by default if on the same day, but not for `OrgClockDate`)

This pull request will probably conflict with #43, as I have put the necessary tests into the same new file, but I wanted to keep the PRs separate. Solving the merge conflict should be straightforward though!