### PR TITLE
orgparse.load() generates a ResourceWarning when called with a text file

### DIFF
--- a/orgparse/__init__.py
+++ b/orgparse/__init__.py
@@ -131,13 +131,15 @@ def load(path: Union[str, Path, TextIO], env: Optional[OrgEnv]=None) -> OrgNode:
     """
     orgfile: TextIO
     if isinstance(path, (str, Path)):
-        orgfile = codecs.open(str(path), encoding='utf8')
+        # Use 'with' to close the file inside this function.
+        with codecs.open(str(path), encoding='utf8') as orgfile:
+            lines = (l.rstrip('\n') for l in orgfile.readlines())
         filename = str(path)
     else:
         orgfile = path
+        lines = (l.rstrip('\n') for l in orgfile.readlines())
         filename = path.name if hasattr(path, 'name') else '<file-like>'
-    return loadi((l.rstrip('\n') for l in orgfile.readlines()),
-                 filename=filename, env=env)
+    return loadi(lines, filename=filename, env=env)
 
 
 def loads(string: str, filename: str='<string>', env: Optional[OrgEnv]=None) -> OrgNode:


### PR DESCRIPTION
Consider the attached files `testorgparse.py` and `test.org`.

The file `testorgparse.py` is a simple test of `orgparse.load()` on an external text file `test.org` using `unittest`. It contains the following:
```
import orgparse
import unittest
import os

class TestLoadOrgFile(unittest.TestCase):
    """A class for testing check_org_file"""

    def test_check_org_file_ok(self):
        file_dir = os.path.dirname(os.path.abspath(__file__))
        test_file = os.path.join(file_dir,"test.org")
        s = orgparse.load(test_file)
        

if __name__ == "__main__":
    # Run self-tests
    unittest.main()
```

The file `test.org` is a simple, one-line org file and should reside in the same directory as `testorgparse.py`. Then, the call below generates a ResourceWarning due to an unclosed file in `loadparse.load()`:
```
$ python3 testorgparse.py 
testorgparse.py:11: ResourceWarning: unclosed file <_io.BufferedReader name='/home/user/python/test.org'>
  s = orgparse.load(test_file)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
.
----------------------------------------------------------------------
Ran 1 test in 0.004s

OK

```

The pushed code fixes the warning by enclosing `codecs.open()` by a `with` statement.

This is the output with the modified code:

```
$ python3 testorgparse.py 
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK

```

[test_load.zip](https://github.com/karlicoss/orgparse/files/7351980/test_load.zip)
