### PR TITLE
Support parsing timestamp cookies (i.e., repeated tasks, and warnings)

### DIFF
--- a/orgparse/tests/test_date.py
+++ b/orgparse/tests/test_date.py
@@ -17,8 +17,10 @@ def test_date_as_string() -> None:
 
     assert str(OrgDate(testdate, testdate2)) == "<2021-09-03 Fri>--<2021-09-05 Sun>"
     assert str(OrgDate(testdate, testdate2)) == "<2021-09-03 Fri>--<2021-09-05 Sun>"
+    assert str(OrgDate(testdatetime, testdatetime2)) == "<2021-09-03 Fri 16:19--17:00>"
     assert str(OrgDate(testdate, testdate2, active=False)) == "[2021-09-03 Fri]--[2021-09-05 Sun]"
     assert str(OrgDate(testdate, testdate2, active=False)) == "[2021-09-03 Fri]--[2021-09-05 Sun]"
+    assert str(OrgDate(testdatetime, testdatetime2, active=False)) == "[2021-09-03 Fri 16:19--17:00]"
 
     assert str(OrgDateScheduled(testdate)) == "<2021-09-03 Fri>"
     assert str(OrgDateScheduled(testdatetime)) == "<2021-09-03 Fri 16:19>"

--- a/orgparse/tests/test_misc.py
+++ b/orgparse/tests/test_misc.py
@@ -214,3 +214,30 @@ foo bar
         OrgDate((2010, 8, 9, 0, 30), (2010, 8, 10, 13, 20)),
         OrgDate((2019, 8, 10, 16, 30, 0), (2019, 8, 10, 17, 30, 0)),
     ]
+
+def test_date_with_cookies() -> None:
+    testcases = [
+        ('<2010-06-21 Mon +1y>', "OrgDate((2010, 6, 21), None, True, ('+', 1, 'y'))"),
+        ('<2005-10-01 Sat +1m>', "OrgDate((2005, 10, 1), None, True, ('+', 1, 'm'))"),
+        ('<2005-10-01 Sat +1m -3d>', "OrgDate((2005, 10, 1), None, True, ('+', 1, 'm'), ('-', 3, 'd'))"),
+        ('<2005-10-01 Sat -3d>', "OrgDate((2005, 10, 1), None, True, None, ('-', 3, 'd'))"),
+        ('<2008-02-10 Sun ++1w>', "OrgDate((2008, 2, 10), None, True, ('++', 1, 'w'))"),
+        ('<2008-02-08 Fri 20:00 ++1d>', "OrgDate((2008, 2, 8, 20, 0, 0), None, True, ('++', 1, 'd'))"),
+        ('<2019-04-05 Fri 08:00 .+1h>', "OrgDate((2019, 4, 5, 8, 0, 0), None, True, ('.+', 1, 'h'))"),
+        ('[2019-04-05 Fri 08:00 .+1h]', "OrgDate((2019, 4, 5, 8, 0, 0), None, False, ('.+', 1, 'h'))"),
+        ('<2007-05-16 Wed 12:30 +1w>', "OrgDate((2007, 5, 16, 12, 30, 0), None, True, ('+', 1, 'w'))"),
+    ]
+    for (input, expected) in testcases:
+        root = loads(input)
+        output = root[0].datelist[0]
+        assert str(output) == input
+        assert repr(output) == expected
+    testcases = [
+        ('<2006-11-02 Thu 20:00-22:00 +1w>', "OrgDate((2006, 11, 2, 20, 0, 0), (2006, 11, 2, 22, 0, 0), True, ('+', 1, 'w'))"),
+        ('<2006-11-02 Thu 20:00--22:00 +1w>', "OrgDate((2006, 11, 2, 20, 0, 0), (2006, 11, 2, 22, 0, 0), True, ('+', 1, 'w'))"),
+    ]
+    for (input, expected) in testcases:
+        root = loads(input)
+        output = root[0].rangelist[0]
+        assert str(output) == "<2006-11-02 Thu 20:00--22:00 +1w>"
+        assert repr(output) == expected


### PR DESCRIPTION
This pull request solves issue #15 

## Format Definition in the OrgMode manual
- [8.1 Timestamps](https://orgmode.org/manual/Timestamps.html): timestamp with repeater interval.
- [8.3 Deadlines and Scheduling](https://orgmode.org/manual/Deadlines-and-Scheduling.html): deadline warnings.
- [8.3.2 Repeated tasks](https://orgmode.org/manual/Repeated-tasks.html): repeating tasks, and the ordering when jointly used with warnings.

## Description
- Added a `_repeater` and a `_warning` field in `OrgDate` class. Both of them are a 3-element tuple `(prefix, number, interval)`.
- Didn't modify the `OrgDate.from_str` method, so `from_str` does not support repeaters and warnings.
- Added some tests

## Unsupported format examples

These edge cases isn't supported by OrgMode, so we don't need to support them:

```
<2022-03-07 Mon 02:00 +1w>--<2022-03-07 Mon 04:00 +1w>
<2022-03-07 Mon 02:00 +1w>--<2022-03-07 Mon 04:00>
<2022-03-07 Mon 02:00>--<2022-03-07 Mon 04:00 +1w>
```

## [Further Improvements] Use `OrgDate` as an iterator?

Here are some test cases:

```py
def test_date_iterator() -> None:
    testcases = [
        ('<2022-03-07 Mon 02:00 +1h>', '<2022-03-07 Mon 03:00 +1h>'),
        ('<2022-03-07 Mon +1d>', '<2022-03-08 Tue +1d>'),
        ('<2022-03-07 Mon +1w>', '<2022-03-14 Mon +1w>'),
        ('<2022-03-07 Mon +1m>', '<2022-04-07 Thu +1m>'),
        ('<2022-03-31 Thu +1m>', '<2022-05-01 Sun +1m>'),
        ('<2022-03-07 Mon +1y>', '<2023-03-07 Tue +1y>'),
        ('<2024-02-29 Thu +1y>', '<2025-03-01 Sat +1y>'),
    ]
    for (input, expected) in testcases:
        root = loads(input)
        output = root[0].datelist[0]
        assert str(output) == input
        assert str(next(output)) == expected
```

We may add something like this in `OrgDate`:

```py
def __iter__(self):
    return self

def __next__(self):
    if self._repeater is not None:
        odate = OrgDate(self._start, self._end, self._active,
                        self._repeater, self._warning)
        num = self._repeater[1]
        interval = self._repeater[2]
        d = {'h': 'hours', 'd': 'days', 'w': 'weeks', 'm': 'months', 'y': 'years'}
        timedelta = datetime.timedelta(**{d[interval]: num})
        odate._start += timedelta
        if odate._end:
            odate._end += timedelta
        return odate
    else:
        raise StopIteration
```

However, `datetime.timedelta` does not support `months` and `years`. We may use [python-dateutil](https://dateutil.readthedocs.io/en/latest/) for this, but it'll introduce an extra external dependency. Implement the behavior by hand is error-prone, so we may discuss how to implement this in the future.