### PR TITLE
Pathlib open

### DIFF
--- a/orgparse/__init__.py
+++ b/orgparse/__init__.py
@@ -140,8 +140,7 @@ def load(path: Union[str, Path, TextIO], env: Optional[OrgEnv] = None) -> OrgNod
             return load(orgfile, env)
 
     # We assume it is a file-like object (e.g. io.StringIO)
-    all_lines = path.readlines()
-    all_lines = (line.rstrip('\n') for line in all_lines)
+    all_lines = (line.rstrip('\n') for line in path)
 
     # get the filename
     filename = path.name if hasattr(path, 'name') else '<file-like>'

--- a/orgparse/__init__.py
+++ b/orgparse/__init__.py
@@ -133,11 +133,11 @@ def load(path: Union[str, Path, TextIO], env: Optional[OrgEnv] = None) -> OrgNod
     orgfile = path
 
     # file-like object (e.g. io.StringIO)
-    try:
+    if isinstance(path, io.IOBase):
         # This will raise an AttributeError if it's not a file-like object.
         all_lines = orgfile.readlines()
         all_lines = (line.rstrip('\n') for line in all_lines)
-    except AttributeError:
+    else:
         # Make sure it is a Path object.
         if isinstance(path, str):
             path = Path(path)
@@ -148,10 +148,7 @@ def load(path: Union[str, Path, TextIO], env: Optional[OrgEnv] = None) -> OrgNod
             return load(orgfile, env)
 
     # get the filename
-    try:
-        filename = path.name
-    except AttributeError:
-        filename = '<file-like>'
+    filename = path.name if hasattr(path, 'name') else '<file-like>'
 
     return loadi(all_lines, filename=filename, env=env)
 

--- a/orgparse/__init__.py
+++ b/orgparse/__init__.py
@@ -130,19 +130,22 @@ def load(path: Union[str, Path, TextIO], env: Optional[OrgEnv] = None) -> OrgNod
     """
     orgfile: TextIO
 
-    # file-like object (e.g. io.StringIO)
-    if isinstance(path, IOBase):
-        orgfile = path
-        all_lines = orgfile.readlines()
+    orgfile = path
 
-    else:
+    # file-like object (e.g. io.StringIO)
+    try:
+        # This will raise an AttributeError if it's not a file-like object.
+        all_lines = orgfile.readlines()
+        all_lines = (line.rstrip('\n') for line in all_lines)
+    except AttributeError:
         # Make sure it is a Path object.
         if isinstance(path, str):
             path = Path(path)
 
-        # open
+        # open that Path
         with path.open('r', encoding='utf8') as orgfile:
-            all_lines = orgfile.readlines()
+            # try again loading
+            return load(orgfile, env)
 
     # get the filename
     try:

--- a/orgparse/__init__.py
+++ b/orgparse/__init__.py
@@ -133,7 +133,7 @@ def load(path: Union[str, Path, TextIO], env: Optional[OrgEnv] = None) -> OrgNod
     orgfile = path
 
     # file-like object (e.g. io.StringIO)
-    if isinstance(path, io.IOBase):
+    if isinstance(path, IOBase):
         # This will raise an AttributeError if it's not a file-like object.
         all_lines = orgfile.readlines()
         all_lines = (line.rstrip('\n') for line in all_lines)

--- a/orgparse/__init__.py
+++ b/orgparse/__init__.py
@@ -128,24 +128,20 @@ def load(path: Union[str, Path, TextIO], env: Optional[OrgEnv] = None) -> OrgNod
     :rtype: :class:`orgparse.node.OrgRootNode`
 
     """
-    orgfile: TextIO
+    # Make sure it is a Path object.
+    if isinstance(path, str):
+        path = Path(path)
 
-    orgfile = path
-
-    # file-like object (e.g. io.StringIO)
-    if isinstance(path, IOBase):
-        # This will raise an AttributeError if it's not a file-like object.
-        all_lines = orgfile.readlines()
-        all_lines = (line.rstrip('\n') for line in all_lines)
-    else:
-        # Make sure it is a Path object.
-        if isinstance(path, str):
-            path = Path(path)
-
+    # if it is a Path
+    if isinstance(path, Path):
         # open that Path
         with path.open('r', encoding='utf8') as orgfile:
             # try again loading
             return load(orgfile, env)
+
+    # We assume it is a file-like object (e.g. io.StringIO)
+    all_lines = path.readlines()
+    all_lines = (line.rstrip('\n') for line in all_lines)
 
     # get the filename
     filename = path.name if hasattr(path, 'name') else '<file-like>'


### PR DESCRIPTION
Here we are. I will give details about the improvements and arguments for them in direct code comments.

# Intention
My intention was a "bug" I haven't reported in an Issue. I can't use `orgpase` in my unittests when using `pyfakefs`. The latter use "faked" `Path` objects that are not recognized by that line.

`if isinstance(path, (str, Path)):`

With this fix my own code using pyfakefs works well.