### PR TITLE
Parse timestamp cookies for SCHEDULED and DEADLINE

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest] # TODO windows-latest??
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        # seems like 3.6 isn't available on their osx image anymore
-        exclude: [{platform: macos-latest, python-version: '3.6'}]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.platform }}
 

--- a/orgparse/date.py
+++ b/orgparse/date.py
@@ -527,7 +527,20 @@ class OrgDateSDCBase(OrgDate):
                 end_dict.update(mdict)
                 end_dict.update({'hour': end_hour, 'min': end_min})
                 end = cls._datetuple_from_groupdict(end_dict)
-            return cls(start, end, active=cls._active_default)
+            cookie_suffix = ['pre', 'num', 'dwmy']
+            repeater: Optional[Tuple[str, int, str]] = None
+            warning: Optional[Tuple[str, int, str]] = None
+            prefix = ''
+            if mdict[prefix + 'repeatpre'] is not None:
+                keys = [prefix + 'repeat' + suffix for suffix in cookie_suffix]
+                values = [mdict[k] for k in keys]
+                repeater = (values[0], int(values[1]), values[2])
+            if mdict[prefix + 'warnpre'] is not None:
+                keys = [prefix + 'warn' + suffix for suffix in cookie_suffix]
+                values = [mdict[k] for k in keys]
+                warning = (values[0], int(values[1]), values[2])
+            return cls(start, end, active=cls._active_default,
+                       repeater=repeater, warning=warning)
         else:
             return cls(None)
 

--- a/orgparse/tests/test_misc.py
+++ b/orgparse/tests/test_misc.py
@@ -217,15 +217,24 @@ foo bar
 
 def test_date_with_cookies() -> None:
     testcases = [
-        ('<2010-06-21 Mon +1y>', "OrgDate((2010, 6, 21), None, True, ('+', 1, 'y'))"),
-        ('<2005-10-01 Sat +1m>', "OrgDate((2005, 10, 1), None, True, ('+', 1, 'm'))"),
-        ('<2005-10-01 Sat +1m -3d>', "OrgDate((2005, 10, 1), None, True, ('+', 1, 'm'), ('-', 3, 'd'))"),
-        ('<2005-10-01 Sat -3d>', "OrgDate((2005, 10, 1), None, True, None, ('-', 3, 'd'))"),
-        ('<2008-02-10 Sun ++1w>', "OrgDate((2008, 2, 10), None, True, ('++', 1, 'w'))"),
-        ('<2008-02-08 Fri 20:00 ++1d>', "OrgDate((2008, 2, 8, 20, 0, 0), None, True, ('++', 1, 'd'))"),
-        ('<2019-04-05 Fri 08:00 .+1h>', "OrgDate((2019, 4, 5, 8, 0, 0), None, True, ('.+', 1, 'h'))"),
-        ('[2019-04-05 Fri 08:00 .+1h]', "OrgDate((2019, 4, 5, 8, 0, 0), None, False, ('.+', 1, 'h'))"),
-        ('<2007-05-16 Wed 12:30 +1w>', "OrgDate((2007, 5, 16, 12, 30, 0), None, True, ('+', 1, 'w'))"),
+        ('<2010-06-21 Mon +1y>',
+         "OrgDate((2010, 6, 21), None, True, ('+', 1, 'y'))"),
+        ('<2005-10-01 Sat +1m>',
+         "OrgDate((2005, 10, 1), None, True, ('+', 1, 'm'))"),
+        ('<2005-10-01 Sat +1m -3d>',
+         "OrgDate((2005, 10, 1), None, True, ('+', 1, 'm'), ('-', 3, 'd'))"),
+        ('<2005-10-01 Sat -3d>',
+         "OrgDate((2005, 10, 1), None, True, None, ('-', 3, 'd'))"),
+        ('<2008-02-10 Sun ++1w>',
+         "OrgDate((2008, 2, 10), None, True, ('++', 1, 'w'))"),
+        ('<2008-02-08 Fri 20:00 ++1d>',
+         "OrgDate((2008, 2, 8, 20, 0, 0), None, True, ('++', 1, 'd'))"),
+        ('<2019-04-05 Fri 08:00 .+1h>',
+         "OrgDate((2019, 4, 5, 8, 0, 0), None, True, ('.+', 1, 'h'))"),
+        ('[2019-04-05 Fri 08:00 .+1h]',
+         "OrgDate((2019, 4, 5, 8, 0, 0), None, False, ('.+', 1, 'h'))"),
+        ('<2007-05-16 Wed 12:30 +1w>',
+         "OrgDate((2007, 5, 16, 12, 30, 0), None, True, ('+', 1, 'w'))"),
     ]
     for (input, expected) in testcases:
         root = loads(input)
@@ -233,11 +242,58 @@ def test_date_with_cookies() -> None:
         assert str(output) == input
         assert repr(output) == expected
     testcases = [
-        ('<2006-11-02 Thu 20:00-22:00 +1w>', "OrgDate((2006, 11, 2, 20, 0, 0), (2006, 11, 2, 22, 0, 0), True, ('+', 1, 'w'))"),
-        ('<2006-11-02 Thu 20:00--22:00 +1w>', "OrgDate((2006, 11, 2, 20, 0, 0), (2006, 11, 2, 22, 0, 0), True, ('+', 1, 'w'))"),
+        ('<2006-11-02 Thu 20:00-22:00 +1w>',
+         "OrgDate((2006, 11, 2, 20, 0, 0), (2006, 11, 2, 22, 0, 0), True, ('+', 1, 'w'))"),
+        ('<2006-11-02 Thu 20:00--22:00 +1w>',
+         "OrgDate((2006, 11, 2, 20, 0, 0), (2006, 11, 2, 22, 0, 0), True, ('+', 1, 'w'))"),
     ]
     for (input, expected) in testcases:
         root = loads(input)
         output = root[0].rangelist[0]
         assert str(output) == "<2006-11-02 Thu 20:00--22:00 +1w>"
         assert repr(output) == expected
+    # DEADLINE and SCHEDULED
+    testcases2 = [
+        ('* TODO Pay the rent\nDEADLINE: <2005-10-01 Sat +1m>',
+         "<2005-10-01 Sat +1m>",
+         "OrgDateDeadline((2005, 10, 1), None, True, ('+', 1, 'm'))"),
+        ('* TODO Pay the rent\nDEADLINE: <2005-10-01 Sat +1m -3d>',
+         "<2005-10-01 Sat +1m -3d>",
+         "OrgDateDeadline((2005, 10, 1), None, True, ('+', 1, 'm'), ('-', 3, 'd'))"),
+        ('* TODO Pay the rent\nDEADLINE: <2005-10-01 Sat -3d>',
+         "<2005-10-01 Sat -3d>",
+         "OrgDateDeadline((2005, 10, 1), None, True, None, ('-', 3, 'd'))"),
+        ('* TODO Pay the rent\nDEADLINE: <2005-10-01 Sat ++1m>',
+         "<2005-10-01 Sat ++1m>",
+         "OrgDateDeadline((2005, 10, 1), None, True, ('++', 1, 'm'))"),
+        ('* TODO Pay the rent\nDEADLINE: <2005-10-01 Sat .+1m>',
+         "<2005-10-01 Sat .+1m>",
+         "OrgDateDeadline((2005, 10, 1), None, True, ('.+', 1, 'm'))"),
+    ]
+    for (input, expected_str, expected_repr) in testcases2:
+        root = loads(input)
+        output = root[1].deadline
+        assert str(output) == expected_str
+        assert repr(output) == expected_repr
+    testcases2 = [
+        ('* TODO Pay the rent\nSCHEDULED: <2005-10-01 Sat +1m>',
+         "<2005-10-01 Sat +1m>",
+         "OrgDateScheduled((2005, 10, 1), None, True, ('+', 1, 'm'))"),
+        ('* TODO Pay the rent\nSCHEDULED: <2005-10-01 Sat +1m -3d>',
+         "<2005-10-01 Sat +1m -3d>",
+         "OrgDateScheduled((2005, 10, 1), None, True, ('+', 1, 'm'), ('-', 3, 'd'))"),
+        ('* TODO Pay the rent\nSCHEDULED: <2005-10-01 Sat -3d>',
+         "<2005-10-01 Sat -3d>",
+         "OrgDateScheduled((2005, 10, 1), None, True, None, ('-', 3, 'd'))"),
+        ('* TODO Pay the rent\nSCHEDULED: <2005-10-01 Sat ++1m>',
+         "<2005-10-01 Sat ++1m>",
+         "OrgDateScheduled((2005, 10, 1), None, True, ('++', 1, 'm'))"),
+        ('* TODO Pay the rent\nSCHEDULED: <2005-10-01 Sat .+1m>',
+         "<2005-10-01 Sat .+1m>",
+         "OrgDateScheduled((2005, 10, 1), None, True, ('.+', 1, 'm'))"),
+    ]
+    for (input, expected_str, expected_repr) in testcases2:
+        root = loads(input)
+        output = root[1].scheduled
+        assert str(output) == expected_str
+        assert repr(output) == expected_repr

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 3.5
+minversion = 3.7
 # relies on the correct version of Python installed
 envlist = tests,mypy
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ minversion = 3.7
 envlist = tests,mypy
 
 [testenv]
-passenv = CI CI_*
+passenv = CI,CI_*
 
 [testenv:tests]
 commands =


### PR DESCRIPTION
Fix #15 completely.

Related: #50 

~~This PR also follows setuptools_scm v7.0.0 [to drop Python 3.6 support](https://github.com/pypa/setuptools_scm/blob/main/CHANGELOG.rst#v700), since orgparse requires `setuptools_scm`.~~

**Update**: Python 3.6 support is already dropped in a later commit (0041aad535836b5faf540205c8c68d5e42b52e19).